### PR TITLE
🐛 Fix TheBrain backup files deletion issue

### DIFF
--- a/theBrain/Resize-TheBrainNotesYouTubeThumbnail.ps1
+++ b/theBrain/Resize-TheBrainNotesYouTubeThumbnail.ps1
@@ -3,7 +3,9 @@
   Resize YouTube thumbnails down to 30% in theBrain Notes
 
 .DESCRIPTION
-  Append `#$width=30p$` to the image address within the Markdown files
+  Scan all Markdown files in the user's Brain data directory, and apends `#$width=30p$`
+  to the image URL of embedded YouTube thumbnails within the Markdown files, and backs
+  up the original notes to the Backup folder before changing the Markdown file content.
 
 .PARAMETER None
 
@@ -17,7 +19,7 @@
   PS C:\> .\Resize-TheBrainNotesYouTubeThumbnail.ps1
 
 .NOTES
-  Version:        1.1.5
+  Version:        2.0.0
   Author:         chriskyfung
   License:        GNU GPLv3 license
   Original from:  https://gist.github.com/chriskyfung/ff65df9a60a7a544ff12aa8f810d728a/
@@ -28,44 +30,38 @@
 # Enable Verbose output
 [CmdletBinding()]
 
+$ErrorActionPreference = "Stop"
+
 # Look up the Notes.md files that locate under the Brain data folder and contain the YouTube thumbnail URLs.
 $BrainFolder = . "$PSScriptRoot\Get-TheBrainDataDirectory.ps1"
-$MatchInfo = Get-ChildItem -Path $BrainFolder -Filter 'Notes.md' -Recurse | Select-String '\/(hq|maxres)default.jpg\)' -List
+$BackupFolder = Join-Path $BrainFolder 'Backup'
+
+$Filename = 'Notes.md'
+$FilenameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($Filename)
+$FileExtension = [System.IO.Path]::GetExtension($Filename)
+
+Write-Host 'Scanning YouTube thumbnail URLs in Brain Notes...'
+$MatchInfo = Get-ChildItem -Path $BrainFolder -Exclude $BackupFolder -Filter $Filename -Recurse | Select-String '\/(hq|maxres)default.jpg\)' -List
 
 # For each matching result
+Write-Information 'Backing up and modifying Brain Notes...'
 ForEach ($Match in $MatchInfo) {
   $FilePath = $Match.Path | Convert-Path # FilePath of the Notes.md file
-  $ParentFolder = Split-Path -Path $FilePath # Path of the parent folder
-  # Check if any backup files exist in the parent folder
-  $NewIndex = 1
-  if (Test-Path -Path ( -join ($FilePath, '.bak*')) -PathType leaf) {
-    # If true then determine the index of the last backup file
-    $LastIndex = (Get-ChildItem -Path $ParentFolder -Filter '*.bak*' | Select-Object Extension -Unique |
-      Sort-Object -Property Extension | Select-Object -Last 1)[0] -replace ('\D*', '')
-    $NewIndex = [int]$LastIndex
-    # If there are more than three backup files
-    if ($NewIndex -ge 3) {
-      # Remove the first backup file and re-index the rest of the backup files
-      Remove-Item ( -join ($FilePath, '.bak1'))
-      Rename-Item ( -join ($FilePath, '.bak2')) -NewName ( -join ($FilePath, '.bak1'))
-      Rename-Item ( -join ($FilePath, '.bak3')) -NewName ( -join ($FilePath, '.bak2'))
-    }
-    else {
-      # Else increment the index for the new backup file
-      $NewIndex++
-    }
-  }
-  $NewName = -join ($FilePath, '.bak', $NewIndex) # FilePath of the new backup file
-  Copy-Item $FilePath -Destination $NewName # Backup the Notes.md file
-  Write-Verbose "Created -->' $NewName"
+  $ParentFolder = Split-Path -Path $FilePath -Parent # Path of the parent folder
+  $Timestamp = (Get-Item $FilePath).LastWriteTime.ToString('yyyyMMdd_HHmmss')
+  $BackupFilename = "$FilenameWithoutExtension-$Timestamp$FileExtension~"
+  $BackupPath = Join-Path $ParentFolder.Replace($BrainFolder, $BackupFolder) $BackupFilename
+  # Backup the Notes.md file
+  Copy-Item -Path $FilePath -Destination (New-Item -ItemType File -Force -Path $BackupPath) -Force
+  Write-Verbose "Created --> '$BackupPath'"
   # Amend the link of the YouTube thumbnail with UTF8 encoding
   $Pattern = $Match.Matches.Value
   $NewString = $Pattern.Replace(')', '#$width=30p$)')
   (Get-Content $FilePath -Encoding UTF8).Replace($Pattern, $NewString) | Set-Content $FilePath -Encoding UTF8
-  Write-Verbose "Modified -->' $FilePath"
+  Write-Verbose "Modified --> '$FilePath'"
 }
 
-Write-Host $MatchInfo.Length 'file(s) found' # Output the number of files found
+Write-Host 'Finished: ' $MatchInfo.Length 'file(s) found' # Output the number of files found
 
 $MatchInfo | Format-Table Path | Out-Host # Output the path of the files found
 


### PR DESCRIPTION
This commit fixes #2 the issue of backup files being clean up by TheBrain program.

Here are the changes made to `Resize-TheBrainNotesYouTubeThumbnail.ps1`:

- Raised the semantic version number to 2.0.0
- Updated the .DESCRIPTION in the comment-based help
- Added `$ErrorActionPreference` to stop execution immediately
- Added verbose messages to indicate the operating stages
- Introduced a folder called "Backup" in the user's Brain data directory as the file backup location
- Revamped the code to create backup files by copying the original file to a path under the Backup folder instead of the source directory
- Removed the limits of backup files being kept
- Introduced a timestamp-formatted filename to backup files
- Refactored to use a variable called `$Filename` instead of hardcoding the filename of Brain Markdown notes ("Notes.md") inline
- Used the `-Parent` option to ensure the `Split-Path` cmdlet returns the parent folder of target files