### PR TITLE
fix(theBrain): Improve link extraction and data directory handling

### DIFF
--- a/theBrain/Get-TheBrainDataDirectory.ps1
+++ b/theBrain/Get-TheBrainDataDirectory.ps1
@@ -15,11 +15,11 @@
   System.String. The script returns the absolute path to the user's TheBrain data directory.
 
 .NOTES
-  Version:        1.1.0
-  Author:         chriskyfung, Gemini
+  Version:        1.1.1
+  Author:         chriskyfung
   License:        GNU GPLv3 license
   Creation Date:  2025-11-10
-  Last Modified:  2025-08-01
+  Last Modified:  2025-09-06
 #>
 
 #Requires -Version 2.0
@@ -43,8 +43,9 @@ try {
     $result = Invoke-SqliteQuery -DataSource $theBrainMetaDatabase -Query $query
     $brainDataDirectory = $result.Value.Trim('"').Replace('\\', '\')
 
-    if ($null -eq $brainDataDirectory) {
-      $brainDataDirectory = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath 'Brains'
+    if ($null -eq $brainDataDirectory -or $brainDataDirectory -eq '') {
+        # Default to 'Brains' folder in 'My Documents' if no value is found
+        $brainDataDirectory = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath 'Brains'
     }
 
     # Check if the folder exists

--- a/theBrain/Get-TheBrainNotesLinks.ps1
+++ b/theBrain/Get-TheBrainNotesLinks.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
   This script searches for all markdown links within the 'Notes.md' files in your TheBrain data directory.
-  It then displays the results in a DataTable view and provides an option to save the results as a CSV file.
+  It then displays the results in a list and provides an option to save the results as a CSV file.
 
 .PARAMETER Path
   The path to search for notes. If not specified, it will use the default TheBrain data directory.
@@ -14,21 +14,21 @@
 
 .EXAMPLE
   PS C:\> .\Get-TheBrainNotesLinks.ps1
-  Searches for links in the default TheBrain data directory and displays them in a DataTable.
+  Searches for links in the default TheBrain data directory and displays them in a List.
 
 .EXAMPLE
   PS C:\> .\Get-TheBrainNotesLinks.ps1 -OutputPath "C:\temp\links.csv"
   Searches for links and saves the results to a CSV file.
 
 .OUTPUTS
-  System.Data.DataTable. The script outputs a DataTable containing the found links.
+  System.Object[]. The script outputs an array of custom objects, each with Path, LineNumber, LinkText, and URL properties.
 
 .NOTES
-  Version:        1.2.0
+  Version:        1.3.0
   Author:         chriskyfung, Gemini
   License:        GNU GPLv3 license
   Creation Date:  2023-06-24
-  Last Modified:  2025-08-01
+  Last Modified:  2025-09-07
 #>
 
 #Requires -Version 2.0
@@ -50,10 +50,20 @@ try {
     $PathToSearch = Get-ChildItem -Directory -Path $Path -Exclude 'Backup'
     # Regex to find all markdown links
     $MatchInfo = Get-ChildItem -Path $PathToSearch -Filter 'Notes.md' -Recurse | Select-String -Pattern '(?!-{)\[([^\]]+)\]\((https?://[^()]+)\)(?!}-)' -AllMatches
-    $LinkList = $MatchInfo | Select-Object *, @{Name = "MarkdownLink"; Expression = { $_.Matches.Value } }, @{Name = "LinkText"; Expression = { $_.Matches.Groups[1].Value } } , @{Name = "URL"; Expression = { $_.Matches.Groups[2].Value } }
+    $LinkList = @($MatchInfo | ForEach-Object {
+        $currentMatchInfo = $_
+        $currentMatchInfo.Matches | ForEach-Object {
+            [PSCustomObject]@{
+                Path       = $currentMatchInfo.Path
+                LineNumber = $currentMatchInfo.LineNumber
+                LinkText   = $_.Groups[1].Value
+                URL        = $_.Groups[2].Value
+            }
+        }
+    })
 
-    # Output the results in DataTable view
-    $LinkList | Out-DataTable
+    # Output the results in a list
+    $LinkList | Format-List -Property Path, LineNumber, LinkText, URL
 
     # Save the results as a CSV file if an output path is specified
     if ($OutputPath) {


### PR DESCRIPTION
This PR addresses two issues in `theBrain` scripts:

- Corrects the link extraction logic and improves the output formatting in `Get-TheBrainNotesLinks.ps1`.
- Adds a check to handle cases where the database path for the data directory is empty in `Get-TheBrainDataDirectory.ps1`.

This improves the robustness and reliability of the scripts.