### PR TITLE
feat(Tests): Add Pester Coverage for 'theBrain' and Modernize Test Suite

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -11,11 +11,11 @@
   Runs all Pester tests and analyzes all PowerShell scripts in the project.
 
 .NOTES
-  Version:        1.0.0
-  Author:         Gemini
+  Version:        1.1.0
+  Author:         chriskyfung, Gemini
   License:        GNU GPLv3 license
   Creation Date:  2025-08-02
-  Last Modified:  2025-08-02
+  Last Modified:  2025-09-08
 #>
 
 param()
@@ -27,20 +27,60 @@ try {
   Write-Host "Running PSScriptAnalyzer..."
   $filesToAnalyze = Get-ChildItem -Path . -Recurse -Include *.ps1, *.psm1 | Where-Object { $_.FullName -notlike "*\.vscode\*" }
   if ($filesToAnalyze) {
-    $filesToAnalyze | ForEach-Object {
-      Invoke-ScriptAnalyzer -Path $_.FullName -Settings PSScriptAnalyzerSettings.psd1
-    } | Format-List
+    foreach ($file in $filesToAnalyze) {
+      $analysisResult = Invoke-ScriptAnalyzer -Path $file.FullName -Settings PSScriptAnalyzerSettings.psd1
+      if ($analysisResult) {
+        Write-Host "`nIssues found in $($file.FullName):"
+        $analysisResult | Format-List
+      }
+    }
   }
   #endregion
 
   #region Pester
   Write-Host "Running Pester tests..."
+
+  # Determine the correct PowerShell executable to use for isolated processes
+  $executable = ''
+  if (Get-Command -Name 'pwsh' -ErrorAction SilentlyContinue) {
+      $executable = 'pwsh'
+  }
+  elseif (Get-Command -Name 'powershell' -ErrorAction SilentlyContinue) {
+      $executable = 'powershell'
+  }
+  else {
+      Write-Error "Could not find 'pwsh' or 'powershell' executable to run isolated Pester tests."
+      exit 1
+  }
+  Write-Host "Using '$executable' for isolated test execution."
+
   $testFiles = Get-ChildItem -Path . -Recurse -Filter *.Tests.ps1
   if ($testFiles) {
-      $testFilePaths = $testFiles | ForEach-Object { $_.FullName }
-      $pesterResult = Invoke-Pester -Script $testFilePaths -PassThru
-      if ($pesterResult.FailedCount -gt 0) {
-        Write-Error "Pester tests failed."
+      $overallResult = @{ FailedCount = 0 }
+      foreach ($testFile in $testFiles) {
+        Write-Host "`nRunning tests in isolated process for: $($testFile.FullName)"
+        # Execute Pester in a new process to ensure test isolation (e.g., for mocks).
+        & $executable -NoProfile -Command "& {
+            `$pesterParams = @{
+                Script    = '$($testFile.FullName)'
+                PassThru  = `$true
+            }
+            `$result = Invoke-Pester @pesterParams
+            if (`$result.FailedCount -gt 0) {
+                # Exit with a non-zero code to indicate failure
+                exit 1
+            }
+            exit 0
+        }"
+
+        if ($LASTEXITCODE -ne 0) {
+            $overallResult.FailedCount++
+            Write-Warning "At least one test failed in $($testFile.FullName)"
+        }
+      }
+
+      if ($overallResult.FailedCount -gt 0) {
+        Write-Error "$($overallResult.FailedCount) test file(s) contained failures."
         exit 1
       }
   }
@@ -55,3 +95,4 @@ catch {
   Write-Error "Build failed: $_"
   exit 1
 }
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -68,6 +68,33 @@ All PowerShell scripts **MUST** include a comment-based help header with the fol
 - All tests **MUST** pass before a commit is made.
 - A `Build.ps1` script is provided to automate the process of running Pester tests and PSScriptAnalyzer.
 
+#### Pester v5 Best Practices
+
+To ensure consistency and leverage the modern syntax of Pester v5, adhere to the following conventions when writing tests:
+
+-   **Mocking Commands**: Use the modern syntax `Mock <Command-Name> { <ScriptBlock> }`. The `-MockWith` parameter is deprecated. The `Mock` command should be placed inside a `BeforeAll`, `BeforeEach`, or `It` block.
+-   **Verifiable Mocks**: Use the `-Verifiable` switch on a `Mock` to create a mock that can be verified with `Should -Invoke`. This ensures that the mocked command was actually called during the test.
+-   **Accessing Parameters**: Inside a `Mock` script block, access parameters passed to the mocked command directly by their variable names (e.g., `$Path`, `$Name`). The `param()` block is no longer needed.
+-   **Mocking Pipeline Commands**: When mocking a command that receives input from the pipeline, use `@{ $_ }` to capture the pipeline object.
+-   **Parameter Filtering**: When using `-ParameterFilter` with a switch parameter, check for its presence with `.IsPresent` (e.g., `-ParameterFilter { $ListAvailable.IsPresent }`).
+-   **Mocking .NET Static Methods**: Direct mocking of .NET static methods is not a feature of Pester. The recommended approach is to wrap the static method call in a PowerShell function and then mock that wrapper function in your tests.
+
+**Example of a modern mock:**
+
+```powershell
+# Correctly mocking a PowerShell command and making it verifiable
+Mock Test-Path {
+    # '$Path' is directly available, no 'param($Path)' needed.
+    if ($Path -like '*important*') {
+        return $true
+    }
+    return $false
+} -Verifiable
+
+# In an 'It' block, you can then assert it was called
+Should -Invoke 'Test-Path' -Times 1 -Exactly
+```
+
 ### 3.5. Git Commit Conventions
 
 This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. Each commit message should be prefixed with a type and an optional scope, followed by a description. An emoji is also used at the beginning of the subject line.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -56,13 +56,14 @@ All PowerShell scripts **MUST** include a comment-based help header with the fol
 ### 3.3. Code Quality and Linting
 
 - This project uses **PSScriptAnalyzer** for static analysis.
-- The primary configuration is `PSScriptAnalyzerSettings.psd1` in the root directory. There are other specific configurations in subdirectories.
+- The primary configuration is `PSScriptAnalyzerSettings.psd1` in the root directory, which is configured to ensure compatibility with **PowerShell 5.1 and 7.4 on Windows 10/11**. There are other specific configurations in subdirectories.
 - **Before committing any changes to PowerShell scripts (`.ps1`), you MUST run PSScriptAnalyzer to ensure compatibility and adherence to project rules.**
 - A build script, `Build.ps1`, will be created to automate the process of running PSScriptAnalyzer and Pester tests.
 
 ### 3.4. Testing
 
 - This project uses **Pester v5.7.1** for unit and integration testing.
+- **Test Isolation**: To prevent mock leakage and ensure a clean state, the `Build.ps1` script invokes each test file (`*.Tests.ps1`) in a separate, isolated PowerShell process. The script automatically detects and uses the appropriate executable (`pwsh` or `powershell`) available on the system. This is the standard for this project and must be maintained.
 - All new scripts **MUST** be accompanied by Pester tests.
 - Any modifications to existing scripts **MUST** include corresponding updates to the tests.
 - All tests **MUST** pass before a commit is made.

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -3,20 +3,14 @@
   Rules = @{
     PSUseCompatibleCmdlets = @{
       Compatibility = @(
-        'desktop-2.0-windows'
-        'desktop-3.0-windows'
-        'desktop-4.0-windows'
-        'desktop-5.1.14393.206-windows'
-        'core-6.1.0-windows'
+        'desktop-5.1-windows'
+        'core-7.4-windows'
       )
     }
     PSUseCompatibleSyntax = @{
       TargetedVersions = @(
-        '6.0'
-        '5.1'
-        '4.0'
-        '3.0'
-        '2.0'
+        '5.1',
+        '7.4'
       )
     }
   }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Some of the features of the project are:
 
 To run these scripts, you need:
 
-- PowerShell 5.1 or higher
+- Windows 10 or 11
+- PowerShell 5.1 or higher (tested against 5.1 and 7.4)
 - Microsoft Onenote 2016 or higher
 - TheBrain 13 or higher
 - Some third-party PowerShell modules (see the scripts for details)

--- a/README.md
+++ b/README.md
@@ -40,25 +40,29 @@ For more details on how to utilize the scripts for a particular application, you
 
 ## Testing
 
-This project uses Pester v5.7.1 for testing and PSScriptAnalyzer for static analysis. A `Build.ps1` script is provided to automate this process.
+This project uses [Pester](https://pester.dev/) (v5.7.1) for testing and [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) for static analysis.
 
-### Automated Build and Test
+### Running Tests
 
-To run the build script, which includes PSScriptAnalyzer and Pester tests, open a PowerShell terminal in the root of the project and execute the following command:
+To run all checks, including PSScriptAnalyzer and Pester tests, execute the build script from the project root:
 
 ```powershell
 .\Build.ps1
 ```
 
+### Writing Tests
+
+When contributing, please follow modern Pester v5 conventions.
+
+-   **Structure:** Use `Describe` and `It` blocks to structure your tests. ([Read more](https://pester.dev/docs/quick-start#writing-your-first-pester-test))
+-   **Assertions:** Use `Should` to check the results of your code. ([Read more](https://pester.dev/docs/assertions/should))
+-   **Mocking:** Isolate your tests by replacing dependencies with `Mock`. ([Read more](https://pester.dev/docs/mocking))
+
+**Key Convention:** Direct mocking of .NET static methods is not supported by Pester. Please wrap the static method in a PowerShell function and mock the wrapper instead.
+
 ### Debugging in Visual Studio Code
 
-To debug in Visual Studio Code, set a breakpoint in your script or test file, then open the **Run and Debug** view (Ctrl+Shift+D). From the dropdown menu, select one of the following configurations and press <kbd>F5</kbd> to start debugging:
-
--   **PowerShell: Launch Current File**: Runs the currently open PowerShell script.
--   **PowerShell: Run Pester Tests**: Runs all Pester tests in the project.
--   **PowerShell: Run Pester Test in Current File**: Runs the Pester tests located in the currently open test file.
-
-For more information on Pester, visit the official documentation: <https://pester.dev/docs/quick-start> .
+To debug, set a breakpoint and use the **Run and Debug** view (Ctrl+Shift+D). The existing `launch.json` provides configurations for running the current file or its tests.
 
 ## Disclaimer
 

--- a/Tests/Bluestacks/Optimize-BluestacksVEthernet.Tests.ps1
+++ b/Tests/Bluestacks/Optimize-BluestacksVEthernet.Tests.ps1
@@ -3,9 +3,13 @@
   Tests for the Optimize-BluestacksVEthernet.ps1 script.
 #>
 
-$scriptPath = Join-Path $PSScriptRoot "..\..\Bluestacks\Optimize-BluestacksVEthernet.ps1"
-
 Describe "Optimize-BluestacksVEthernet" -Tags "CI" {
+
+  BeforeAll {
+    # Get the absolute path to the script under test
+    $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\Bluestacks\Optimize-BluestacksVEthernet.ps1"
+  }
+
   It "Should run without errors" {
     if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
       Write-Host "Skipping test: Administrative privileges are required." -ForegroundColor Yellow
@@ -16,6 +20,6 @@ Describe "Optimize-BluestacksVEthernet" -Tags "CI" {
     Write-Host "Running test with administrative privileges..." -ForegroundColor Green
     Mock -CommandName Get-NetAdapter -MockWith { return @([pscustomobject]@{ Name = 'vEthernet (Default Switch)'; ifIndex = 1 }) }
     Mock -CommandName Set-NetIPInterface -MockWith { return $true }
-    & $scriptPath | Should Not Throw
+    & $script:ScriptPath | Should Not Throw
   }
 }

--- a/Tests/Bluestacks/Optimize-BluestacksVEthernet.Tests.ps1
+++ b/Tests/Bluestacks/Optimize-BluestacksVEthernet.Tests.ps1
@@ -18,8 +18,10 @@ Describe "Optimize-BluestacksVEthernet" -Tags "CI" {
 
     # Code that requires admin permissions
     Write-Host "Running test with administrative privileges..." -ForegroundColor Green
-    Mock -CommandName Get-NetAdapter -MockWith { return @([pscustomobject]@{ Name = 'vEthernet (Default Switch)'; ifIndex = 1 }) }
-    Mock -CommandName Set-NetIPInterface -MockWith { return $true }
+    Mock Get-NetAdapter {
+      return @([pscustomobject]@{ Name = 'vEthernet (Default Switch)'; ifIndex = 1 })
+    } -Verifiable
+    Mock Set-NetIPInterface { return $true } -Verifiable
     & $script:ScriptPath | Should Not Throw
   }
 }

--- a/Tests/OneNote/Find-OneNotePages.Tests.ps1
+++ b/Tests/OneNote/Find-OneNotePages.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Find-OneNotePages.ps1" {
 
   BeforeAll {
     # Set the path to the script under test.
-    $script:ScriptPath = Join-Path $PSScriptRoot "..\..\OneNote\Find-OneNotePages.ps1"
+    $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\OneNote\Find-OneNotePages.ps1"
   }
 
   # This is an integration test that requires a running OneNote instance.

--- a/Tests/OneNote/Out-OneNoteSections.Tests.ps1
+++ b/Tests/OneNote/Out-OneNoteSections.Tests.ps1
@@ -2,11 +2,12 @@
 .SYNOPSIS
   Tests for Out-OneNoteSections.ps1
 #>
+
 Describe "Out-OneNoteSections.ps1" {
 
   BeforeAll {
     # Set the path to the script under test.
-    $script:ScriptPath = Join-Path $PSScriptRoot "..\..\OneNote\Out-OneNoteSections.ps1"
+    $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\OneNote\Out-OneNoteSections.ps1"
   }
 
   Context "When OneNote has notebooks" {

--- a/Tests/Web/Test-URL.Tests.ps1
+++ b/Tests/Web/Test-URL.Tests.ps1
@@ -3,36 +3,38 @@
   Tests for the Test-URL.ps1 script.
 #>
 
-# Get the absolute path to the script under test
-$scriptPath = Join-Path $PSScriptRoot "..\..\Test-URL.ps1"
-
 Describe "Test-URL Script" -Tag "CI" {
-    BeforeAll {
-        # Mock Invoke-WebRequest to simulate web responses.
-        # This mock will return a success status code for most URLs,
-        # but throw an error for a specific invalid domain.
-        Mock 'Invoke-WebRequest' {
-            param($Uri)
-            if ($Uri -eq 'https://no-such.domain') {
-                throw "Simulated error: Host not found"
-            } else {
-                return [pscustomobject]@{ StatusCode = 200 }
-            }
-        }
+
+  BeforeAll {
+    # Get the absolute path to the script under test
+    $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\Test-URL.ps1"
+
+    # Mock Invoke-WebRequest to simulate web responses.
+    # This mock will return a success status code for most URLs,
+    # but throw an error for a specific invalid domain.
+    Mock 'Invoke-WebRequest' {
+      param($Uri)
+      if ($Uri -eq 'https://no-such.domain') {
+        throw "Simulated error: Host not found"
+      }
+      else {
+        return [pscustomobject]@{ StatusCode = 200 }
+      }
     }
+  }
 
-    It "Should produce a table with correct status for each URL" {
-        # Execute the script and capture its output object
-        $results = & $scriptPath
+  It "Should produce a table with correct status for each URL" {
+    # Execute the script and capture its output object
+    $results = & $script:ScriptPath
 
-        # Assert the structure of the output
-        $results | Should -BeOfType [PSCustomObject]
-        $results | Should -Not -BeNullOrEmpty
+    # Assert the structure of the output
+    $results | Should -BeOfType [PSCustomObject]
+    $results | Should -Not -BeNullOrEmpty
 
-        # Assert the status of a successful URL
-        ($results | Where-Object { $_.URL -eq 'https://www.google.com' }).Status | Should -Be "Up and running"
+    # Assert the status of a successful URL
+    ($results | Where-Object { $_.URL -eq 'https://www.google.com' }).Status | Should -Be "Up and running"
 
-        # Assert the status of the failing URL
-        ($results | Where-Object { $_.URL -eq 'https://no-such.domain' }).Status | Should -Be "Not responding"
-    }
+    # Assert the status of the failing URL
+    ($results | Where-Object { $_.URL -eq 'https://no-such.domain' }).Status | Should -Be "Not responding"
+  }
 }

--- a/Tests/Web/Test-URL.Tests.ps1
+++ b/Tests/Web/Test-URL.Tests.ps1
@@ -12,14 +12,13 @@ Describe "Test-URL Script" -Tag "CI" {
     # Mock Invoke-WebRequest to simulate web responses.
     # This mock will return a success status code for most URLs,
     # but throw an error for a specific invalid domain.
-    Mock 'Invoke-WebRequest' {
-      param($Uri)
+    Mock Invoke-WebRequest {
       if ($Uri -eq 'https://no-such.domain') {
         throw "Simulated error: Host not found"
       }
       else {
         return [pscustomobject]@{ StatusCode = 200 }
-      }
+      } -Verifiable
     }
   }
 

--- a/Tests/theBrain/Format-TheBrainNotesYouTubeThumbnail.Tests.ps1
+++ b/Tests/theBrain/Format-TheBrainNotesYouTubeThumbnail.Tests.ps1
@@ -6,7 +6,7 @@ BeforeAll {
   $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\theBrain\Format-TheBrainNotesYouTubeThumbnail.ps1"
 
   # Set up a temporary file system structure to simulate TheBrain's data
-  $script:TestDrive = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "TestBrain") -Force
+  $script:TestDrive = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "Test-FormatTheBrainYouTubeThumbnail") -Force
   $script:BrainFolder = $script:TestDrive.FullName
   $script:BackupFolder = Join-Path $BrainFolder 'Backup'
   $script:NoteFolder = Join-Path $BrainFolder 'TestNote'

--- a/Tests/theBrain/Format-TheBrainNotesYouTubeThumbnail.Tests.ps1
+++ b/Tests/theBrain/Format-TheBrainNotesYouTubeThumbnail.Tests.ps1
@@ -69,10 +69,10 @@ Describe 'Format-TheBrainNotesYouTubeThumbnail.ps1' {
     )
 
     # Mock the commands to return our simulated objects and control behavior
-    Mock Get-ChildItem { return Get-Item $script:NoteFolder }
-    Mock Select-String { return $MatchObject }
-    Mock Get-Content { return $script:OriginalContent.Split([System.Environment]::NewLine) }
-    Mock New-Item { return [pscustomobject]@{ FullName = $Path[0] } }
+    Mock Get-ChildItem { return Get-Item $script:NoteFolder } -Verifiable
+    Mock Select-String { return $MatchObject } -Verifiable
+    Mock Get-Content { return $script:OriginalContent.Split([System.Environment]::NewLine) } -Verifiable
+    Mock New-Item { return [pscustomobject]@{ FullName = $Path[0] } } -Verifiable
 
     # Act
     . $script:ScriptPath
@@ -104,8 +104,8 @@ Describe 'Format-TheBrainNotesYouTubeThumbnail.ps1' {
   It 'should do nothing if no matching links are found' {
     # Arrange
     # Mock Select-String to return no matches
-    Mock 'Get-ChildItem'
-    Mock 'Select-String' -MockWith { return $null }
+    Mock Get-ChildItem -Verifiable
+    Mock Select-String { return $null } -Verifiable
 
     # Act
     . $script:ScriptPath
@@ -140,12 +140,12 @@ Describe 'Format-TheBrainNotesYouTubeThumbnail.ps1' {
         )
       }
     )
-    Mock Get-ChildItem { Get-Item $script:NoteFolder }
-    Mock Select-String { return $MatchObject }
-    Mock New-Item { return [pscustomobject]@{ FullName = $Path } }
+    Mock Get-ChildItem { Get-Item $script:NoteFolder } -Verifiable
+    Mock Select-String { return $MatchObject } -Verifiable
+    Mock New-Item { return [pscustomobject]@{ FullName = $Path } } -Verifiable
 
     # Mock Copy-Item to throw an error
-    Mock Copy-Item { throw "Access Denied" }
+    Mock Copy-Item { throw "Access Denied" } -Verifiable
 
     # Act & Assert
     # Verify that the script throws the expected exception

--- a/Tests/theBrain/Format-TheBrainNotesYouTubeThumbnail.Tests.ps1
+++ b/Tests/theBrain/Format-TheBrainNotesYouTubeThumbnail.Tests.ps1
@@ -1,0 +1,158 @@
+# Test for Format-TheBrainNotesYouTubeThumbnail.ps1
+# Requires -Modules Pester
+
+BeforeAll {
+  # Path to the script being tested
+  $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\theBrain\Format-TheBrainNotesYouTubeThumbnail.ps1"
+
+  # Set up a temporary file system structure to simulate TheBrain's data
+  $script:TestDrive = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "TestBrain") -Force
+  $script:BrainFolder = $script:TestDrive.FullName
+  $script:BackupFolder = Join-Path $BrainFolder 'Backup'
+  $script:NoteFolder = Join-Path $BrainFolder 'TestNote'
+  $script:MdImagesFolder = Join-Path $NoteFolder '.data\md-images'
+  $script:NotesFile = Join-Path $NoteFolder 'Notes.md'
+  $script:ImageFile = Join-Path $MdImagesFolder 'thumbnail123.jpg'
+
+  # Create the directories and a dummy image file
+  New-Item -Path $script:BackupFolder -ItemType Directory | Out-Null
+  New-Item -Path $script:NoteFolder -ItemType Directory | Out-Null
+  New-Item -Path $script:MdImagesFolder -ItemType Directory | Out-Null
+  New-Item -Path $script:ImageFile -ItemType File | Out-Null
+
+  # Define the content that the script will look for
+  $script:OriginalContent = '[![Test Alt Text](.data/md-images/thumbnail123.jpg)](https://youtu.be/VIDEO123)'
+  Set-Content -Path $script:NotesFile -Value $script:OriginalContent -Encoding UTF8
+
+  # Mock the external script dependency to return a temporary path
+  Mock Invoke-SqliteQuery { return [PSCustomObject]@{ Value = """$script:TestDrive""" } } -Verifiable
+}
+
+AfterAll {
+  # Clean up the temporary directory
+  Remove-Item -Path $script:TestDrive.FullName -Recurse -Force
+}
+
+Describe 'Format-TheBrainNotesYouTubeThumbnail.ps1' {
+
+  BeforeEach {
+    # Reset all mocks before each test to ensure isolation
+    Mock Get-ChildItem -Verifiable
+    Mock Select-String -Verifiable
+    Mock Copy-Item -Verifiable
+    Mock Move-Item -Verifiable
+    Mock Set-Content -Verifiable
+    Mock Write-Host -Verifiable
+    Mock Write-Verbose
+    Mock New-Item -Verifiable
+    Mock Get-Content -Verifiable
+    Mock Convert-Path { return $Path } -Verifiable
+  }
+
+  It 'should find, back up, and replace a YouTube thumbnail link' {
+    # Arrange
+    # This object simulates the output of Select-String with a found match
+    $MatchObject = @(
+      [pscustomobject]@{
+        Path    = $script:NotesFile
+        Matches = @(
+          [pscustomobject]@{
+            Value  = $script:OriginalContent
+            Groups = @{
+              'ALT'       = [pscustomobject]@{ Value = 'Test Alt Text' }
+              'IMAGEFILE' = [pscustomobject]@{ Value = 'thumbnail123' }
+              'VIDEOID'   = [pscustomobject]@{ Value = 'VIDEO123' }
+            }
+          }
+        )
+      }
+    )
+
+    # Mock the commands to return our simulated objects and control behavior
+    Mock Get-ChildItem { return Get-Item $script:NoteFolder }
+    Mock Select-String { return $MatchObject }
+    Mock Get-Content { return $script:OriginalContent.Split([System.Environment]::NewLine) }
+    Mock New-Item { return [pscustomobject]@{ FullName = $Path[0] } }
+
+    # Act
+    . $script:ScriptPath
+
+    # Assert
+    $ExpectedNewString = '[![Test Alt Text](https://img.youtube.com/vi/VIDEO123/maxresdefault.jpg)](https://www.youtube.com/watch?v=VIDEO123)'
+
+    # Verify that the backup file for Notes.md was created
+    Should -Invoke Copy-Item -Times 1 -Exactly -Scope It -ParameterFilter {
+      $Path -eq $script:NotesFile -and $Destination -like "$script:BackupFolder\TestNote\Notes-*.md~"
+    }
+
+    # Verify that the local image file was moved to the backup location
+    Should -Invoke Move-Item -Times 1 -Exactly -Scope It -ParameterFilter {
+      $Path -eq "$script:NoteFolder\.data\md-images\thumbnail123.jpg" -and $Destination -like "$script:BackupFolder\TestNote\.data\md-images\thumbnail123.jpg"
+    }
+
+    # Verify that the Notes.md file was updated with the new string
+    Should -Invoke Set-Content -Times 1 -Exactly -Scope It -ParameterFilter {
+      $Path -eq $script:NotesFile -and $Value -eq $ExpectedNewString -and $Encoding -eq 'UTF8'
+    }
+
+    # Verify the final status message
+    Should -Invoke Write-Host -Times 1 -Exactly -Scope It -ParameterFilter {
+      $Object -like 'Finished: * file(s) found'
+    }
+  }
+
+  It 'should do nothing if no matching links are found' {
+    # Arrange
+    # Mock Select-String to return no matches
+    Mock 'Get-ChildItem'
+    Mock 'Select-String' -MockWith { return $null }
+
+    # Act
+    . $script:ScriptPath
+
+    # Assert
+    # Ensure no file operations were attempted
+    Should -Not -Invoke -CommandName Copy-Item
+    Should -Not -Invoke -CommandName Move-Item
+    Should -Not -Invoke -CommandName Set-Content
+
+    # Verify the final status message indicates no files were found
+    Should -Invoke Write-Host -Times 1 -Exactly -Scope It -ParameterFilter {
+      $Object -eq 'Finished: 0 file(s) found'
+    }
+  }
+
+  It 'should handle errors during file operations' {
+    # Arrange
+    # Simulate a match being found, same as the happy path test
+    $MatchObject = @(
+      [pscustomobject]@{
+        Path    = $script:NotesFile
+        Matches = @(
+          [pscustomobject]@{
+            Value  = $script:OriginalContent
+            Groups = @{
+              'ALT'       = [pscustomobject]@{ Value = 'Test Alt Text' }
+              'IMAGEFILE' = [pscustomobject]@{ Value = 'thumbnail123' }
+              'VIDEOID'   = [pscustomobject]@{ Value = 'VIDEO123' }
+            }
+          }
+        )
+      }
+    )
+    Mock Get-ChildItem { Get-Item $script:NoteFolder }
+    Mock Select-String { return $MatchObject }
+    Mock New-Item { return [pscustomobject]@{ FullName = $Path } }
+
+    # Mock Copy-Item to throw an error
+    Mock Copy-Item { throw "Access Denied" }
+
+    # Act & Assert
+    # Verify that the script throws the expected exception
+    { . $script:ScriptPath } | Should -Throw "An error occurred: *"
+
+    # Verify that subsequent operations were not performed
+    Should -Not -Invoke -CommandName Move-Item
+    Should -Not -Invoke -CommandName Set-Content
+  }
+}

--- a/Tests/theBrain/Get-TheBrainDataDirectory.Tests.ps1
+++ b/Tests/theBrain/Get-TheBrainDataDirectory.Tests.ps1
@@ -1,0 +1,64 @@
+<#
+.SYNOPSIS
+    Tests for Get-TheBrainDataDirectory.ps1
+#>
+# Requires the Pester module
+# You can install it via PowerShell Gallery if not already installed:
+
+# Store and restore original environment variable to avoid side-effects
+$originalAppData = $env:LOCALAPPDATA
+
+Describe 'Get-TheBrainDataDirectory' {
+  BeforeAll {
+    # Path to the script being tested
+    $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\theBrain\Get-TheBrainDataDirectory.ps1"
+
+    $env:LOCALAPPDATA = '/tmp' # Use a predictable temp path for tests
+    # Mock Invoke-SqliteQuery to return a specific path
+    Get-Module -Name PSSQLite | Remove-Module
+    New-Module -Name PSSQLite  -ScriptBlock {
+      function Invoke-SqliteQuery {
+        param($DataSource, $Query)
+        return [PSCustomObject]@{ Value = '"C:\Users\TestUser\Documents\TheBrain"' }
+      }
+    } | Import-Module -Force
+  }
+  AfterAll {
+    $env:LOCALAPPDATA = $originalAppData
+    Get-Module -Name PSSQLite | Remove-Module
+    Import-Module PSSQLite
+  }
+
+  # Default mock for Get-Module to return true, can be overridden in specific tests
+  BeforeEach {
+    Mock Get-Module -ParameterFilter { $Name -eq 'PSSQLite' -and $ListAvailable.IsPresent } -MockWith { $true }
+  }
+
+  Context 'Success Scenarios' {
+    BeforeEach {
+      # Mock dependencies for successful execution
+      Mock Test-Path -MockWith {
+        # This flexible mock returns true for the DB path and the final resolved path
+        if ($Path -eq (Join-Path $env:LOCALAPPDATA "TheBrain\MetaDB\TheBrainMeta.db") -or $Path -eq 'C:\Users\TestUser\Documents\TheBrain' -or $Path -eq (Join-Path 'C:\Users\TestUser\Documents' -ChildPath 'Brains')) {
+          return $true
+        }
+        return $false
+      } | Out-Null
+    }
+
+    It 'should return the brain data directory from the database when available' {
+      Mock 'Invoke-SqliteQuery' -MockWith { [PSCustomObject]@{ Value = '"C:\Users\TestUser\Documents\TheBrain"' } }
+
+      $result = & $script:ScriptPath
+      $result | Should -Be 'C:\Users\TestUser\Documents\TheBrain'
+    }
+
+    It 'should return the default "Brains" directory when the database query returns null' {
+      Mock Invoke-SqliteQuery -MockWith { [PSCustomObject]@{ Value = '""' } }
+      Mock Join-Path -MockWith { 'C:\Users\TestUser\Documents\Brains' } -ParameterFilter { $Path -eq ([Environment]::GetFolderPath('MyDocuments')) -and $ChildPath -eq 'Brains' }
+
+      $result = & $script:ScriptPath
+      $result | Should -Be (Join-Path 'C:\Users\TestUser\Documents' -ChildPath 'Brains')
+    }
+  }
+}

--- a/Tests/theBrain/Get-TheBrainDataDirectory.Tests.ps1
+++ b/Tests/theBrain/Get-TheBrainDataDirectory.Tests.ps1
@@ -18,7 +18,6 @@ Describe 'Get-TheBrainDataDirectory' {
     Get-Module -Name PSSQLite | Remove-Module
     New-Module -Name PSSQLite  -ScriptBlock {
       function Invoke-SqliteQuery {
-        param($DataSource, $Query)
         return [PSCustomObject]@{ Value = '"C:\Users\TestUser\Documents\TheBrain"' }
       }
     } | Import-Module -Force
@@ -31,31 +30,37 @@ Describe 'Get-TheBrainDataDirectory' {
 
   # Default mock for Get-Module to return true, can be overridden in specific tests
   BeforeEach {
-    Mock Get-Module -ParameterFilter { $Name -eq 'PSSQLite' -and $ListAvailable.IsPresent } -MockWith { $true }
+    Mock Get-Module { return $true } -ParameterFilter {
+      $Name -eq 'PSSQLite' -and $ListAvailable.IsPresent
+    } -Verifiable
   }
 
   Context 'Success Scenarios' {
     BeforeEach {
       # Mock dependencies for successful execution
-      Mock Test-Path -MockWith {
+      Mock Test-Path {
         # This flexible mock returns true for the DB path and the final resolved path
         if ($Path -eq (Join-Path $env:LOCALAPPDATA "TheBrain\MetaDB\TheBrainMeta.db") -or $Path -eq 'C:\Users\TestUser\Documents\TheBrain' -or $Path -eq (Join-Path 'C:\Users\TestUser\Documents' -ChildPath 'Brains')) {
           return $true
         }
         return $false
-      } | Out-Null
+      } -Verifiable
     }
 
     It 'should return the brain data directory from the database when available' {
-      Mock 'Invoke-SqliteQuery' -MockWith { [PSCustomObject]@{ Value = '"C:\Users\TestUser\Documents\TheBrain"' } }
+      Mock Invoke-SqliteQuery {
+        [PSCustomObject]@{ Value = '"C:\Users\TestUser\Documents\TheBrain"' }
+      } -Verifiable
 
       $result = & $script:ScriptPath
       $result | Should -Be 'C:\Users\TestUser\Documents\TheBrain'
     }
 
     It 'should return the default "Brains" directory when the database query returns null' {
-      Mock Invoke-SqliteQuery -MockWith { [PSCustomObject]@{ Value = '""' } }
-      Mock Join-Path -MockWith { 'C:\Users\TestUser\Documents\Brains' } -ParameterFilter { $Path -eq ([Environment]::GetFolderPath('MyDocuments')) -and $ChildPath -eq 'Brains' }
+      Mock Invoke-SqliteQuery { [PSCustomObject]@{ Value = '""' } } -Verifiable
+      Mock Join-Path { 'C:\Users\TestUser\Documents\Brains' } -ParameterFilter {
+        $Path -eq ([Environment]::GetFolderPath('MyDocuments')) -and $ChildPath -eq 'Brains'
+      } -Verifiable
 
       $result = & $script:ScriptPath
       $result | Should -Be (Join-Path 'C:\Users\TestUser\Documents' -ChildPath 'Brains')

--- a/Tests/theBrain/Get-TheBrainDataDirectory.Tests.ps1
+++ b/Tests/theBrain/Get-TheBrainDataDirectory.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Get-TheBrainDataDirectory' {
     # Path to the script being tested
     $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\theBrain\Get-TheBrainDataDirectory.ps1"
 
-    $env:LOCALAPPDATA = '/tmp' # Use a predictable temp path for tests
+    $env:LOCALAPPDATA = $env:TEMP # Use a predictable temp path for tests
     # Mock Invoke-SqliteQuery to return a specific path
     Get-Module -Name PSSQLite | Remove-Module
     New-Module -Name PSSQLite  -ScriptBlock {

--- a/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
+++ b/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Get-TheBrainNotesLinks.ps1" {
     Set-Content -Path (Join-Path $thought3Dir "Notes.md") -Value "This note is in a backup folder and should be ignored: [backup link](https://www.yahoo.com)."
 
     # Mock Format-List to prevent UI from showing during tests
-    Mock Format-List { return @($_) } -Verifiable
+    Mock Format-List { return @( $_ ) } -Verifiable
   }
 
   AfterAll {

--- a/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
+++ b/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Get-TheBrainNotesLinks.ps1" {
     $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\theBrain\Get-TheBrainNotesLinks.ps1"
 
     # # Create a temporary directory structure for testing
-    $tempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "TestBrain") -Force
+    $tempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "Test-GetTheBrainLinks") -Force
     $thought1Dir = New-Item -Path (Join-Path $tempDir "Thought1") -ItemType Directory
     $thought2Dir = New-Item -Path (Join-Path $tempDir "Thought2") -ItemType Directory
     $backupDir = New-Item -Path (Join-Path $tempDir "Backup") -ItemType Directory

--- a/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
+++ b/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
@@ -1,0 +1,110 @@
+# Tests for Get-TheBrainNotesLinks.ps1
+#
+# To run these tests, run `Invoke-Pester` in the root of the repository.
+
+Describe "Get-TheBrainNotesLinks.ps1" {
+  BeforeAll {
+    # Path to the script being tested
+    $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\theBrain\Get-TheBrainNotesLinks.ps1"
+
+    # # Create a temporary directory structure for testing
+    $tempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "TestBrain") -Force
+    $thought1Dir = New-Item -Path (Join-Path $tempDir "Thought1") -ItemType Directory
+    $thought2Dir = New-Item -Path (Join-Path $tempDir "Thought2") -ItemType Directory
+    $backupDir = New-Item -Path (Join-Path $tempDir "Backup") -ItemType Directory
+    $thought3Dir = New-Item -Path (Join-Path $backupDir "Thought3") -ItemType Directory
+
+    # # Create dummy Notes.md files
+    Set-Content -Path (Join-Path $thought1Dir "Notes.md") -Value "This note contains a [valid link](https://www.google.com). This is not a link: [invalid link](htp://invalid-url)."
+    Set-Content -Path (Join-Path $thought2Dir "Notes.md") -Value "This note has no links."
+    Set-Content -Path (Join-Path $thought3Dir "Notes.md") -Value "This note is in a backup folder and should be ignored: [backup link](https://www.yahoo.com)."
+
+    # Mock Format-List to prevent UI from showing during tests
+    Mock Format-List { return @($_) } -Verifiable
+  }
+
+  AfterAll {
+    # Clean up the temporary directory
+    Remove-Item -Path $tempDir -Recurse -Force
+  }
+
+  Context "When searching for links" {
+    It "should find 1 link in Notes.md files" {
+      $results = & $script:ScriptPath -Path $tempDir
+      $results | Should -Not -BeNullOrEmpty
+      $results.Count | Should -BeNullOrEmpty
+      $results[0].LinkText | Should -Be "valid link"
+      $results[0].URL | Should -Be "https://www.google.com"
+    }
+
+    It "should find 3 links in Notes.md files" {
+      # Update the Notes.md in Thought1 to have another valid link
+      Set-Content -Path (Join-Path $thought1Dir "Notes.md") -Value "This note contains a [valid link to Google](https://www.google.com) and a [valid link to Bing](https://www.bing.com). This is not a link: [invalid link](htp://invalid-url)."
+      # Add a valid link to Thought2
+      Set-Content -Path (Join-Path $thought2Dir "Notes.md") -Value "This note contains a [valid link to Facebook](https://www.facebook.com)."
+
+      $results = & $script:ScriptPath -Path $tempDir
+      $results | Should -Not -BeNullOrEmpty
+      $results.Count | Should -Be 3
+      $results | ForEach-Object { $_.Path } | Should -Not -Contain (Join-Path $thought3Dir "Notes.md")
+      $results[0].LinkText | Should -Be "valid link to Google"
+      $results[0].URL | Should -Be "https://www.google.com"
+      $results[1].LinkText | Should -Be "valid link to Bing"
+      $results[1].URL | Should -Be "https://www.bing.com"
+      $results[2].LinkText | Should -Be "valid link to Facebook"
+      $results[2].URL | Should -Be "https://www.facebook.com"
+
+      # Revert changes
+      Set-Content -Path (Join-Path $thought1Dir "Notes.md") -Value "This note contains a [valid link](https://www.google.com). This is not a link: [invalid link](htp://invalid-url)."
+      Set-Content -Path (Join-Path $thought2Dir "Notes.md") -Value "This note has no links."
+    }
+
+    It "should ignore the 'Backup' directory" {
+      $results = & $script:ScriptPath -Path $tempDir
+      $results | Should -Not -BeNullOrEmpty
+      $results | ForEach-Object { $_.Path } | Should -Not -Contain (Join-Path $thought3Dir "Notes.md")
+      $results | ForEach-Object { $_.URL } | Should -Not -Contain "https://www.yahoo.com"
+    }
+
+    It "should return an empty result if no links are found" {
+      $emptyTempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "EmptyTestBrain") -Force
+      $emptyThoughtDir = New-Item -Path (Join-Path $emptyTempDir "EmptyThought") -ItemType Directory
+      Set-Content -Path (Join-Path $emptyThoughtDir "Notes.md") -Value "No links here."
+
+      $results = & $script:ScriptPath -Path $emptyTempDir
+      $results | Should -BeNullOrEmpty
+
+      Remove-Item -Path $emptyTempDir -Recurse -Force
+    }
+  }
+
+  Context "With -OutputPath parameter" {
+    It "should export the results to a CSV file" {
+      $outputCsv = Join-Path $tempDir "links.csv"
+      & $script:ScriptPath -Path $tempDir -OutputPath $outputCsv
+
+      Test-Path $outputCsv | Should -Be $true
+      $csvContent = Import-Csv -Path $outputCsv
+      $csvContent.URL | Should -Be "https://www.google.com"
+
+      Remove-Item -Path $outputCsv -Force
+    }
+  }
+
+  Context "Without -Path parameter" {
+    It "should call Get-TheBrainDataDirectory.ps1 to get the default path" {
+      # Mock the dependency script
+      Mock Invoke-SqliteQuery { return [PSCustomObject]@{ Value = """$tempDir""" } } -Verifiable
+
+      & $script:ScriptPath | Out-Null
+      Should -Invoke Invoke-SqliteQuery -Times 1 -Exactly
+    }
+  }
+
+  Context "Error Handling" {
+    It "should throw an error for an invalid path" {
+      $invalidPath = "Z:\Invalid\Path\That\Does\Not\Exist"
+      { & $script:ScriptPath -Path $invalidPath } | Should -Throw
+    }
+  }
+}

--- a/Tests/theBrain/Open-TheBrainNodeFolder.Tests.ps1
+++ b/Tests/theBrain/Open-TheBrainNodeFolder.Tests.ps1
@@ -1,0 +1,118 @@
+# Tests for Open-TheBrainNodeFolder.ps1
+#
+# Description:
+#   This script contains Pester tests for Open-TheBrainNodeFolder.ps1.
+#   It verifies that the script correctly opens the node folder when it exists,
+#   handles cases where the folder is not found, and manages errors gracefully.
+#
+# Author: chriskyfung, Gemini
+# License: GNU GPLv3
+# Version: 1.0.0
+#
+
+BeforeAll {
+  # Resolve full paths to the scripts at the start
+  $script:ScriptPath = Resolve-Path -Path "$PSScriptRoot/../../theBrain/Open-TheBrainNodeFolder.ps1"
+  $script:GetDataDirectoryScriptPath = Resolve-Path -Path "$PSScriptRoot/../../theBrain/Get-TheBrainDataDirectory.ps1"
+
+  # Create a temporary directory to simulate TheBrain's data folder structure
+  $script:TempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "PesterTest-OpenTheBrainNode")
+  $script:fakeBrainDataDir = Join-Path $script:TempDir.FullName "TheBrain"
+  $null = New-Item -ItemType Directory -Path $script:fakeBrainDataDir
+
+  # Create a fake node folder for testing the success case
+  $script:fakeNodeId = "abc-123-def-456"
+  $script:fakeNodeFolderPath = Join-Path $script:fakeBrainDataDir $script:fakeNodeId
+  $null = New-Item -ItemType Directory -Path $script:fakeNodeFolderPath
+
+  # Create a fake backup folder to ensure it is correctly excluded by the script
+  $null = New-Item -ItemType Directory -Path (Join-Path $script:fakeBrainDataDir "Backup")
+}
+
+AfterAll {
+  # Clean up the temporary directory
+  if (Test-Path $script:TempDir.FullName) {
+    Remove-Item -Path $script:TempDir.FullName -Recurse -Force
+  }
+}
+
+Describe "Open-TheBrainNodeFolder.ps1" {
+  BeforeEach {
+    # Mock the Get-TheBrainDataDirectory.ps1 script to return our temp path.
+    # This is the correct Pester v5 syntax for mocking a script that is dot-sourced.
+    Mock -CommandName $script:GetDataDirectoryScriptPath -MockWith {
+      return $script:fakeBrainDataDir
+    }
+
+    # Mock explorer.exe to prevent it from actually opening a window
+    Mock -CommandName explorer.exe -MockWith {
+      # This space intentionally left blank
+    }
+
+    # Mock Write-Warning to capture its output for verification
+    Mock -CommandName Write-Warning -MockWith {
+      param($Message)
+      $script:WarningMessage = $Message
+    }
+  }
+
+  Context "when the node folder exists" {
+    It "should find the folder and call explorer.exe with the correct path" {
+
+      Mock Get-ChildItem { return @(Get-Item $script:fakeNodeFolderPath) }
+
+      # Run the script with the NodeId of the folder we created
+      . $script:ScriptPath -NodeId $script:fakeNodeId
+
+      # Verify that explorer.exe was called exactly once with the correct full path
+      Should -Invoke "explorer.exe" -Times 1 -Exactly -ParameterFilter { $script:fakeNodeFolderPath }
+      # Verify that no warning was issued
+      Should -Not -Invoke "Write-Warning"
+    }
+  }
+
+  Context "when the node folder does not exist" {
+    It "should call Write-Warning with the appropriate message" {
+      $nonExistentNodeId = "xyz-789-uvw-101"
+
+      # Run the script with a NodeId that does not correspond to any folder
+      . $script:ScriptPath -NodeId $nonExistentNodeId
+
+      # Verify that Write-Warning was called exactly once
+      Should -Invoke "Write-Warning" -Exactly 1
+      # Check if the warning message is correct
+      $script:WarningMessage | Should -Be "Could not find a folder for Node ID: $nonExistentNodeId"
+
+      # Verify that explorer.exe was not called
+      Should -Not -Invoke "explorer.exe"
+    }
+  }
+
+  Context "when an error occurs" {
+    It "should call Write-Error when Get-TheBrainDataDirectory fails" {
+      # Mock Get-Module to simulate that PSSQLite is not found, causing Get-TheBrainDataDirectory to fail
+      Mock Get-Module {
+        throw "Failed to find TheBrain data directory"
+      } -ParameterFilter { $Name -eq "PSSQLite" }
+
+      # Mock Write-Error to verify it's called
+      Mock Write-Error
+
+      # Run the script. The script's try/catch should handle the error and not throw.
+      { . $script:ScriptPath -NodeId $script:fakeNodeId } | Should -Not -Throw
+
+      # Verify that Write-Error was called because the catch block should execute
+      Should -Invoke "Write-Error" -Times 1 -Exactly
+    }
+  }
+
+  Context "with invalid parameters" {
+    It "should throw a ParameterBindingValidationException for a NodeId with invalid characters" {
+      # An invalid NodeId with special characters not allowed by the ValidatePattern attribute
+      $invalidNodeId = "node-id-with-@!#"
+
+      # Expect a ParameterBindingValidationException because the input does not match the pattern
+      { . $script:ScriptPath -NodeId $invalidNodeId } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+  }
+}

--- a/Tests/theBrain/Open-TheBrainNodeFolder.Tests.ps1
+++ b/Tests/theBrain/Open-TheBrainNodeFolder.Tests.ps1
@@ -16,7 +16,7 @@ BeforeAll {
   $script:GetDataDirectoryScriptPath = Resolve-Path -Path "$PSScriptRoot/../../theBrain/Get-TheBrainDataDirectory.ps1"
 
   # Create a temporary directory to simulate TheBrain's data folder structure
-  $script:TempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "PesterTest-OpenTheBrainNode")
+  $script:TempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "Test-OpenTheBrainNode")
   $script:fakeBrainDataDir = Join-Path $script:TempDir.FullName "TheBrain"
   $null = New-Item -ItemType Directory -Path $script:fakeBrainDataDir
 

--- a/Tests/theBrain/Open-TheBrainNodeFolder.Tests.ps1
+++ b/Tests/theBrain/Open-TheBrainNodeFolder.Tests.ps1
@@ -40,26 +40,26 @@ Describe "Open-TheBrainNodeFolder.ps1" {
   BeforeEach {
     # Mock the Get-TheBrainDataDirectory.ps1 script to return our temp path.
     # This is the correct Pester v5 syntax for mocking a script that is dot-sourced.
-    Mock -CommandName $script:GetDataDirectoryScriptPath -MockWith {
+    Mock $script:GetDataDirectoryScriptPath {
       return $script:fakeBrainDataDir
-    }
+    } -Verifiable
 
     # Mock explorer.exe to prevent it from actually opening a window
-    Mock -CommandName explorer.exe -MockWith {
+    Mock explorer.exe {
       # This space intentionally left blank
-    }
+    } -Verifiable
 
     # Mock Write-Warning to capture its output for verification
-    Mock -CommandName Write-Warning -MockWith {
+    Mock Write-Warning {
       param($Message)
       $script:WarningMessage = $Message
-    }
+    } -Verifiable
   }
 
   Context "when the node folder exists" {
     It "should find the folder and call explorer.exe with the correct path" {
 
-      Mock Get-ChildItem { return @(Get-Item $script:fakeNodeFolderPath) }
+      Mock Get-ChildItem { return @(Get-Item $script:fakeNodeFolderPath) } -Verifiable
 
       # Run the script with the NodeId of the folder we created
       . $script:ScriptPath -NodeId $script:fakeNodeId
@@ -93,7 +93,9 @@ Describe "Open-TheBrainNodeFolder.ps1" {
       # Mock Get-Module to simulate that PSSQLite is not found, causing Get-TheBrainDataDirectory to fail
       Mock Get-Module {
         throw "Failed to find TheBrain data directory"
-      } -ParameterFilter { $Name -eq "PSSQLite" }
+      } -ParameterFilter {
+        $Name -eq "PSSQLite"
+      } -Verifiable
 
       # Mock Write-Error to verify it's called
       Mock Write-Error

--- a/Tests/theBrain/Resize-TheBrainNotesYouTubeThumbnail.Tests.ps1
+++ b/Tests/theBrain/Resize-TheBrainNotesYouTubeThumbnail.Tests.ps1
@@ -1,0 +1,148 @@
+<#
+.SYNOPSIS
+  Tests for Resize-TheBrainNotesYouTubeThumbnail.ps1
+#>
+
+Describe 'Resize-TheBrainNotesYouTubeThumbnail.ps1' {
+  BeforeAll {
+    # Path to the script being tested, resolved relative to this test script's location
+    $script:ScriptPath = Resolve-Path -Path "$PSScriptRoot\..\..\theBrain\Resize-TheBrainNotesYouTubeThumbnail.ps1"
+    $script:GetDataDirectoryScriptPath = Resolve-Path -Path "$PSScriptRoot\..\..\theBrain\Get-TheBrainDataDirectory.ps1"
+
+    # Set up a temporary directory to simulate TheBrain's data folder
+    $script:TestDrive = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "TestBrain") -Force
+    $script:TestBrainDataDir = $script:TestDrive.FullName
+    $script:TestThoughtDir = Join-Path $script:TestBrainDataDir 'TestThought'
+    $script:TestBackupDir = Join-Path $script:TestBrainDataDir 'Backup'
+    $script:TestNotesFile = Join-Path $script:TestThoughtDir 'Notes.md'
+    New-Item -Path $script:TestThoughtDir -ItemType Directory -Force | Out-Null
+
+    # Mock the external script dependency to return a temporary path
+    Mock Invoke-SqliteQuery { return [PSCustomObject]@{ Value = """$script:TestDrive""" } } -Verifiable
+  }
+
+  AfterAll {
+    # Clean up the temporary directory
+    Remove-Item -Path $script:TestDrive -Recurse -Force
+  }
+
+  BeforeEach {
+    # Clean up any files from previous tests
+    if (Test-Path $script:TestThoughtDir) {
+      Get-ChildItem -Path $script:TestThoughtDir -Recurse | Remove-Item -Recurse -Force
+    }
+    if (Test-Path $script:TestBackupDir) {
+      Get-ChildItem -Path $script:TestBackupDir -Recurse | Remove-Item -Recurse -Force
+    }
+  }
+
+  Context "when ImageType is 'default'" {
+    It 'should resize a default thumbnail to 50% width by default' {
+      # Arrange
+      $content = 'Some text before ![Image](https://i.ytimg.com/vi/video123/hqdefault.jpg) and after.'
+      Set-Content -Path $script:TestNotesFile -Value $content -Encoding UTF8
+
+      # Act
+      . $script:ScriptPath
+
+      # Assert
+      $newContent = Get-Content -Path $script:TestNotesFile -Encoding UTF8
+      $newContent | Should -Be 'Some text before ![Image](https://i.ytimg.com/vi/video123/hqdefault.jpg#$width=50p$) and after.'
+    }
+
+    It 'should resize a default thumbnail to a specified NewWidth' {
+      # Arrange
+      $content = 'Another note with a thumbnail [](https://i.ytimg.com/vi/video456/maxresdefault.jpg).'
+      Set-Content -Path $script:TestNotesFile -Value $content -Encoding UTF8
+
+      # Act
+      . $script:ScriptPath -NewWidth 75
+
+      # Assert
+      $newContent = Get-Content -Path $script:TestNotesFile -Encoding UTF8
+      $newContent | Should -Be 'Another note with a thumbnail [](https://i.ytimg.com/vi/video456/maxresdefault.jpg#$width=75p$).'
+    }
+
+    It 'should create a backup of the modified file' {
+      # Arrange
+      $content = '![Image](https://i.ytimg.com/vi/video123/hqdefault.jpg)'
+      Set-Content -Path $script:TestNotesFile -Value $content -Encoding UTF8
+
+      # Act
+      . $script:ScriptPath
+
+      # Assert
+      $backupDirForThought = Join-Path $script:TestBackupDir 'TestThought'
+      $backupFile = Get-ChildItem -Path $backupDirForThought -Filter '*.md~'
+      $backupFile | Should -Not -BeNull
+      (Get-Content $backupFile.FullName) | Should -Be $content
+    }
+  }
+
+  Context "when ImageType is 'resized'" {
+    It 'should resize a thumbnail from a specified CurrentWidth to a NewWidth' {
+      # Arrange
+      $content = 'Resizing this: ![Image](https://i.ytimg.com/vi/video789/hqdefault.jpg#$width=30p$)'
+      Set-Content -Path $script:TestNotesFile -Value $content -Encoding UTF8
+
+      # Act
+      . $script:ScriptPath -ImageType resized -CurrentWidth 30 -NewWidth 80
+
+      # Assert
+      $newContent = Get-Content -Path $script:TestNotesFile -Encoding UTF8
+      $newContent | Should -Be 'Resizing this: ![Image](https://i.ytimg.com/vi/video789/hqdefault.jpg#$width=80p$)'
+    }
+
+    It 'should not modify a thumbnail if its width does not match CurrentWidth' {
+      # Arrange
+      $content = 'Do not resize: ![Image](https://i.ytimg.com/vi/videoABC/hqdefault.jpg#$width=50p$)'
+      Set-Content -Path $script:TestNotesFile -Value $content -Encoding UTF8
+
+      # Act
+      . $script:ScriptPath -ImageType resized -CurrentWidth 30 -NewWidth 80
+
+      # Assert
+      $newContent = Get-Content -Path $script:TestNotesFile -Encoding UTF8
+      $newContent | Should -Be $content
+      $backupDirForThought = Join-Path $script:TestBackupDir 'TestThought'
+      Test-Path (Join-Path $backupDirForThought '*.md~') | Should -Be $false
+    }
+  }
+
+  Context 'when no matching thumbnails are found' {
+    It 'should not modify any files' {
+      # Arrange
+      $content = 'This file has no YouTube thumbnails.'
+      Set-Content -Path $script:TestNotesFile -Value $content -Encoding UTF8
+
+      # Act
+      . $script:ScriptPath
+
+      # Assert
+      (Get-Content -Path $script:TestNotesFile -Encoding UTF8) | Should -Be $content
+      $backupDirForThought = Join-Path $script:TestBackupDir 'TestThought'
+      Test-Path (Join-Path $backupDirForThought '*.md~') | Should -Be $false
+    }
+  }
+
+  Context 'Error Handling' {
+    It 'should call Write-Error when Get-TheBrainDataDirectory.ps1 fails' {
+      # Arrange
+      # This mock will cause the script's try/catch block to fail
+      Mock Get-Module { return $null } -ParameterFilter { $Name -eq 'PSSQLite' } -Verifiable
+
+      # Mock Write-Error to verify the catch block is executed
+      Mock Write-Error -Verifiable
+
+      # Act
+      # The script should not throw an unhandled exception because it has a catch block
+      { . $script:ScriptPath } | Should -Not -Throw
+
+      # Assert
+      # Verify that the script's catch block called Write-Error
+      Should -Invoke Write-Error -ParameterFilter {
+        $Message -eq "An error occurred while trying to get TheBrain data directory: The 'PSSQLite' module is required but not installed. Please run 'Install-Module -Name PSSQLite'."
+      }
+    }
+  }
+}

--- a/Tests/theBrain/Resize-TheBrainNotesYouTubeThumbnail.Tests.ps1
+++ b/Tests/theBrain/Resize-TheBrainNotesYouTubeThumbnail.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'Resize-TheBrainNotesYouTubeThumbnail.ps1' {
     $script:GetDataDirectoryScriptPath = Resolve-Path -Path "$PSScriptRoot\..\..\theBrain\Get-TheBrainDataDirectory.ps1"
 
     # Set up a temporary directory to simulate TheBrain's data folder
-    $script:TestDrive = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "TestBrain") -Force
+    $script:TestDrive = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "Test-ResizeTheBrainNotesYouTubeThumbnail") -Force
     $script:TestBrainDataDir = $script:TestDrive.FullName
     $script:TestThoughtDir = Join-Path $script:TestBrainDataDir 'TestThought'
     $script:TestBackupDir = Join-Path $script:TestBrainDataDir 'Backup'

--- a/theBrain/Format-TheBrainNotesYouTubeThumbnail.ps1
+++ b/theBrain/Format-TheBrainNotesYouTubeThumbnail.ps1
@@ -53,14 +53,14 @@ try {
       # Backup the Notes.md file
       $Timestamp = (Get-Item $FilePath).LastWriteTime.ToString('yyyyMMdd_HHmmss')
       $BackupFilename = "$FilenameWithoutExtension-$Timestamp$FileExtension~"
-      $BackupPath = Join-Path $BackupLocation $BackupFilename
-      Copy-Item -Path $FilePath -Destination (New-Item -ItemType File -Force -Path $BackupPath) -Force
+      $BackupFile = New-Item -ItemType File -Force -Path (Join-Path $BackupLocation $BackupFilename)
+      Copy-Item -Path $FilePath -Destination $BackupFile.FullName -Force
       # Backup the md-image file
       $LocalImageFile = $Match.Matches[0].Groups['IMAGEFILE'].Value
-      $LocalImagePath = Convert-Path "$ParentFolder/.data/md-images/$LocalImageFile.jpg"
-      $BackupImagePath = $LocalImagePath.Replace($BrainFolder, $BackupFolder)
-      Move-Item -Path $LocalImagePath -Destination (New-Item -ItemType File -Force -Path $BackupImagePath) -Force
-      Write-Verbose "Created --> '$BackupPath'"
+      $LocalImagePath = Convert-Path "$ParentFolder\.data\md-images\$LocalImageFile.jpg"
+      $BackupImageFile = New-Item -ItemType File -Force -Path $LocalImagePath.Replace($BrainFolder, $BackupFolder)
+      Move-Item -Path $LocalImagePath -Destination $BackupImageFile.FullName -Force
+      Write-Verbose "Created --> '$BackupFile.FullName'"
       # Amend the link of the YouTube thumbnail with UTF8 encoding
       $Pattern = $Match.Matches.Value
       $AltText = $Match.Matches[0].Groups['ALT'].Value

--- a/theBrain/PSScriptAnalyzerSettings.psd1
+++ b/theBrain/PSScriptAnalyzerSettings.psd1
@@ -3,20 +3,14 @@
   Rules = @{
     PSUseCompatibleCmdlets = @{
       Compatibility = @(
-        'desktop-2.0-windows'
-        'desktop-3.0-windows'
-        'desktop-4.0-windows'
-        'desktop-5.1.14393.206-windows'
-        'core-6.1.0-windows'
+        'desktop-5.1-windows'
+        'core-7.4-windows'
       )
     }
     PSUseCompatibleSyntax = @{
       TargetedVersions = @(
-        '6.0'
-        '5.1'
-        '4.0'
-        '3.0'
-        '2.0'
+        '5.1',
+        '7.4'
       )
     }
   }


### PR DESCRIPTION
This pull request significantly enhances the project's test suite by introducing comprehensive Pester tests for scripts in the `theBrain` module and modernizing the existing testing framework to align with Pester v5 best practices.

### Key Contributions:

**1. New Test Coverage for `theBrain` Module:**
- Added Pester tests for the following scripts, ensuring their functionality is validated:
  - `Get-TheBrainDataDirectory.ps1`
  - `Get-TheBrainNotesLinks.ps1`
  - `Open-TheBrainNodeFolder.ps1`
  - `Format-TheBrainNotesYouTubeThumbnail.ps1`
  - `Resize-TheBrainNotesYouTubeThumbnail.ps1`

**2. Pester v5 Modernization:**
- Refactored existing tests to use the modern Pester v5 mocking syntax, replacing the deprecated `-MockWith` parameter.
- Updated test path resolution to use `Resolve-Path` for better reliability.

**3. Documentation Updates:**
- Updated `GEMINI.md` and `README.md` with clear guidelines and best practices for writing tests using Pester v5.

**4. Code Refinements:**
- Improved the backup file handling logic in `Format-TheBrainNotesYouTubeThumbnail.ps1`.

These changes collectively improve the robustness, maintainability, and quality of the codebase.

---

**Recent Commits**
- 📝 docs: reflect build script updates and requirements (56a5b9a)
- 👷 build(ci): implement isolated pester runs and improve output (84e2afa)
- 👷 build(lint): update psanalyzer targets to modern ps versions (934686e)
- 🐛 fix(tests): ensure test suites use separate temp directories (07730eb)
