### PR TITLE
✨ feat(cherry-studio): Add script to reset Notion MCP OAuth cache

### DIFF
--- a/CherryStudio/README.md
+++ b/CherryStudio/README.md
@@ -1,0 +1,46 @@
+# Cherry Studio PowerShell Scripts
+
+本目錄包含用於管理 [Cherry Studio](https://cherry.ai/) 的 PowerShell 工具腳本。
+
+## 腳本清單
+
+### Reset-CherryStudioNotionMCP.ps1
+
+重置 Cherry Studio 的 Notion MCP OAuth 快取。
+
+**用途：**
+- 清除 Notion MCP (`https://mcp.notion.com/mcp`) 的雜湊命名 OAuth JSON 檔案
+- 重啟 Cherry Studio 後自動觸發重新授權流程
+
+**使用情境：**
+- Notion MCP 授權失效或過期
+- 需要切換 Notion 帳號
+- OAuth token 損壞導致連接問題
+
+**使用方法：**
+```powershell
+.\Reset-CherryStudioNotionMCP.ps1
+```
+
+**執行流程：**
+1. 計算 Notion MCP URL 的 MD5 雜湊值
+2. 在 `~/.cherrystudio/config/mcp/oauth` 目錄中搜尋對應的 JSON 檔案
+3. 刪除找到的 OAuth 快取檔案
+4. 重新啟動 Cherry Studio 以觸發重新授權
+
+## 系統要求
+
+- PowerShell 5.1 或更高版本
+- Cherry Studio v1.8.4（已測試版本）
+- Windows 作業系統
+
+**相容性說明：**
+- Cherry Studio 從 v1.2.5+ 開始支援 MCP 功能
+- 本腳本基於 v1.8.4 的 OAuth 資料儲存結構開發
+- 其他版本的 OAuth 檔案路徑或命名規則可能有所不同
+
+## 注意事項
+
+- 執行腳本前請確保已關閉 Cherry Studio
+- 刪除 OAuth 快取後，需要重新進行 Notion 授權流程
+- 建議在執行前備份重要的授權資訊

--- a/CherryStudio/Reset-CherryStudioNotionMCP.ps1
+++ b/CherryStudio/Reset-CherryStudioNotionMCP.ps1
@@ -1,52 +1,119 @@
 <#
 .SYNOPSIS
-    重置 Cherry Studio 的 Notion MCP OAuth 快取
+    Reset Cherry Studio's Notion MCP OAuth cache
 
 .DESCRIPTION
-    清除 Notion MCP (https://mcp.notion.com/mcp) 的雜湊命名 OAuth JSON 檔案
-    重啟後自動觸發重新授權流程
+    Clear the hash-named OAuth JSON file for Notion MCP (https://mcp.notion.com/mcp)
+    Automatically triggers re-authorization flow after restart
+
+.PARAMETER OauthDir
+    Optional. Override the default OAuth directory path.
+    Default: $env:USERPROFILE\.cherrystudio\config\mcp\oauth
+
+.PARAMETER PassThru
+    Optional. Return the result as an object instead of writing to host.
 
 .EXAMPLE
     .\Reset-CherryStudioNotionMCP.ps1
+
+.EXAMPLE
+    .\Reset-CherryStudioNotionMCP.ps1 -OauthDir "C:\Temp\TestOAuth"
+
+.EXAMPLE
+    $result = .\Reset-CherryStudioNotionMCP.ps1 -PassThru
 #>
 
 [CmdletBinding()]
-param()
+param(
+    # Override the default OAuth directory path (for testing purposes)
+    [string]$OauthDir = (Join-Path $env:USERPROFILE ".cherrystudio\config\mcp\oauth"),
 
-# Notion MCP 伺服器 URL，Cherry Studio 使用此 URL 的 MD5 雜湊作為 OAuth 檔案名稱
+    # Return result as object for testing
+    [switch]$PassThru
+)
+
+# Notion MCP server URL, Cherry Studio uses the MD5 hash of this URL as the OAuth filename
 $url = "https://mcp.notion.com/mcp"
 
-# 計算 URL 的 MD5 雜湊值，用於識別對應的 OAuth 快取檔案
+# Calculate MD5 hash of the URL to identify the corresponding OAuth cache file
 $md5 = [System.Security.Cryptography.MD5]::Create()
 $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
 $hashBytes = $md5.ComputeHash($bytes)
 $hashHex = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
 
 $fullHash = $hashHex.ToLower()
-# Cherry Studio 儲存 OAuth token 的目錄路徑
-$oauthDir = Join-Path $env:USERPROFILE ".cherrystudio\config\mcp\oauth"
 
-Write-Host ""
-Write-Host "Notion MCP URL: $url"
-Write-Host "計算出的雜湊前綴: $fullHash"
-Write-Host "搜尋資料夾: $oauthDir"
-Write-Host ""
+# Build output messages
+$messages = @()
+$messages += "Notion MCP URL: $url"
+$messages += "Calculated hash prefix: $fullHash"
+$messages += "Searching directory: $OauthDir"
 
-# 搜尋符合雜湊前綴的 OAuth JSON 檔案
-$targetFiles = Get-ChildItem -Path $oauthDir -Filter "$fullHash*.json" -ErrorAction SilentlyContinue
+if ($PassThru) {
+    Write-Verbose ($messages -join "`n")
+} else {
+    Write-Host ""
+    $messages | ForEach-Object { Write-Host $_ }
+    Write-Host ""
+}
+
+# Search for OAuth JSON files matching the hash prefix
+$targetFiles = Get-ChildItem -Path $OauthDir -Filter "$fullHash*.json" -ErrorAction SilentlyContinue
+
+$result = @{
+    Success = $false
+    FilesDeleted = @()
+    Message = ""
+}
 
 if ($targetFiles) {
-  Write-Host "找到以下檔案：" -ForegroundColor Yellow
-  $targetFiles | ForEach-Object { Write-Host " - $($_.Name)" }
+    $foundMsg = "Found the following files:"
+    if ($PassThru) {
+        Write-Verbose $foundMsg
+    } else {
+        Write-Host $foundMsg -ForegroundColor Yellow
+    }
 
-  # 刪除找到的 OAuth 快取檔案
-  $targetFiles | Remove-Item -Force
+    $targetFiles | ForEach-Object {
+        if ($PassThru) {
+            Write-Verbose " - $($_.Name)"
+        } else {
+            Write-Host " - $($_.Name)"
+        }
+    }
 
-  Write-Host ""
-  Write-Host "已刪除 Notion MCP 的授權快取檔。" -ForegroundColor Green
-  Write-Host "請重新啟動 Cherry Studio，系統應會自動打開瀏覽器重新授權。"
+    # Delete the found OAuth cache files
+    $deletedFiles = @()
+    $targetFiles | ForEach-Object {
+        $deletedFiles += $_.Name
+        Remove-Item $_.FullName -Force
+    }
+
+    $successMsg = "Notion MCP OAuth cache file has been deleted."
+    if ($PassThru) {
+        Write-Verbose $successMsg
+    } else {
+        Write-Host ""
+        Write-Host $successMsg -ForegroundColor Green
+        Write-Host "Please restart Cherry Studio, the system should automatically open the browser for re-authorization."
+    }
+
+    $result.Success = $true
+    $result.FilesDeleted = $deletedFiles
+    $result.Message = $successMsg
 }
 else {
-  Write-Host "找不到對應的 Notion MCP JSON 檔。" -ForegroundColor Red
-  Write-Host "請確認你曾在這台電腦上成功授權過 Notion MCP。"
+    $notFoundMsg = "No corresponding Notion MCP JSON file found."
+    if ($PassThru) {
+        Write-Verbose $notFoundMsg
+    } else {
+        Write-Host $notFoundMsg -ForegroundColor Red
+        Write-Host "Please confirm that you have successfully authorized Notion MCP on this computer before."
+    }
+
+    $result.Message = $notFoundMsg
+}
+
+if ($PassThru) {
+    return $result
 }

--- a/CherryStudio/Reset-CherryStudioNotionMCP.ps1
+++ b/CherryStudio/Reset-CherryStudioNotionMCP.ps1
@@ -1,0 +1,52 @@
+<#
+.SYNOPSIS
+    重置 Cherry Studio 的 Notion MCP OAuth 快取
+
+.DESCRIPTION
+    清除 Notion MCP (https://mcp.notion.com/mcp) 的雜湊命名 OAuth JSON 檔案
+    重啟後自動觸發重新授權流程
+
+.EXAMPLE
+    .\Reset-CherryStudioNotionMCP.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+# Notion MCP 伺服器 URL，Cherry Studio 使用此 URL 的 MD5 雜湊作為 OAuth 檔案名稱
+$url = "https://mcp.notion.com/mcp"
+
+# 計算 URL 的 MD5 雜湊值，用於識別對應的 OAuth 快取檔案
+$md5 = [System.Security.Cryptography.MD5]::Create()
+$bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+$hashBytes = $md5.ComputeHash($bytes)
+$hashHex = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
+
+$fullHash = $hashHex.ToLower()
+# Cherry Studio 儲存 OAuth token 的目錄路徑
+$oauthDir = Join-Path $env:USERPROFILE ".cherrystudio\config\mcp\oauth"
+
+Write-Host ""
+Write-Host "Notion MCP URL: $url"
+Write-Host "計算出的雜湊前綴: $fullHash"
+Write-Host "搜尋資料夾: $oauthDir"
+Write-Host ""
+
+# 搜尋符合雜湊前綴的 OAuth JSON 檔案
+$targetFiles = Get-ChildItem -Path $oauthDir -Filter "$fullHash*.json" -ErrorAction SilentlyContinue
+
+if ($targetFiles) {
+  Write-Host "找到以下檔案：" -ForegroundColor Yellow
+  $targetFiles | ForEach-Object { Write-Host " - $($_.Name)" }
+
+  # 刪除找到的 OAuth 快取檔案
+  $targetFiles | Remove-Item -Force
+
+  Write-Host ""
+  Write-Host "已刪除 Notion MCP 的授權快取檔。" -ForegroundColor Green
+  Write-Host "請重新啟動 Cherry Studio，系統應會自動打開瀏覽器重新授權。"
+}
+else {
+  Write-Host "找不到對應的 Notion MCP JSON 檔。" -ForegroundColor Red
+  Write-Host "請確認你曾在這台電腦上成功授權過 Notion MCP。"
+}

--- a/CherryStudio/Reset-CherryStudioNotionMCP.ps1
+++ b/CherryStudio/Reset-CherryStudioNotionMCP.ps1
@@ -32,6 +32,8 @@ param(
     [switch]$PassThru
 )
 
+$ErrorActionPreference = "Stop"
+
 # Notion MCP server URL, Cherry Studio uses the MD5 hash of this URL as the OAuth filename
 $url = "https://mcp.notion.com/mcp"
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Some of the features of the project are:
 -   **TheBrain**: You can use scripts to interact with theBrain, a powerful software for mind mapping and knowledge management.
 -   **Windows**: Use scripts to manage system components and applications, such as optimizing Docker Desktop's disk usage or monitoring disk health.
 -   **Bluestacks**: You can use scripts to perform tasks and actions in Bluestacks, an emulator that lets you run Android apps on PC.
+-   **Cherry Studio**: Scripts for managing Cherry Studio MCP (Model Context Protocol) integrations, including OAuth reset utilities for Notion MCP.
 -   **And more**: You can use scripts for other purposes, such as web scraping, file management, text processing, etc.
 
 ## Requirements
@@ -20,6 +21,7 @@ To run these scripts, you need:
 - PowerShell 5.1 or higher (tested against 5.1 and 7.4)
 - Microsoft Onenote 2016 or higher
 - TheBrain 13 or higher
+- Cherry Studio v1.8.4 (tested version, MCP support since v1.2.5+)
 - Some third-party PowerShell modules (see the scripts for details)
 
 ## Usage

--- a/Tests/CherryStudio/Reset-CherryStudioNotionMCP.Tests.ps1
+++ b/Tests/CherryStudio/Reset-CherryStudioNotionMCP.Tests.ps1
@@ -1,0 +1,225 @@
+﻿<#
+.SYNOPSIS
+    Tests for Reset-CherryStudioNotionMCP.ps1
+
+.DESCRIPTION
+    Unit tests for the Cherry Studio Notion MCP OAuth reset script.
+    Uses mocked directories to avoid accidentally deleting production OAuth files.
+#>
+
+Describe "Reset-CherryStudioNotionMCP.ps1" -Tag 'Unit' {
+
+  BeforeAll {
+    # Set the path to the script under test.
+    $script:ScriptPath = Resolve-Path "$PSScriptRoot\..\..\CherryStudio\Reset-CherryStudioNotionMCP.ps1"
+
+    # Mock the OAuth directory path - use TEMP to avoid touching real OAuth files
+    $script:MockOauthDir = Join-Path $env:TEMP "CherryStudioTest-OAuth-$(Get-Random)"
+
+    # Store the real OAuth directory path for verification (should never be accessed)
+    $script:RealOauthDir = Join-Path $env:USERPROFILE ".cherrystudio\config\mcp\oauth"
+
+    # Safety check: ensure mock directory is NOT the real OAuth directory
+    $script:MockOauthDir | Should -Not -Be $script:RealOauthDir
+  }
+
+  BeforeEach {
+    # Create mock OAuth directory
+    if (Test-Path $script:MockOauthDir) {
+      Remove-Item $script:MockOauthDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $script:MockOauthDir -Force | Out-Null
+  }
+
+  AfterEach {
+    # Clean up mock OAuth directory
+    if (Test-Path $script:MockOauthDir) {
+      Remove-Item $script:MockOauthDir -Recurse -Force
+    }
+  }
+
+  Context "MD5 Hash Calculation" {
+
+    It "should calculate correct MD5 hash for Notion MCP URL" {
+      $url = "https://mcp.notion.com/mcp"
+      $md5 = [System.Security.Cryptography.MD5]::Create()
+      $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+      $hashBytes = $md5.ComputeHash($bytes)
+      $hashHex = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
+      $expectedHash = $hashHex.ToLower()
+
+      # The expected hash should be a valid 32-character hexadecimal string
+      $expectedHash | Should -Match "^[a-f0-9]{32}$"
+    }
+
+    It "should produce consistent hash for the same URL" {
+      $url = "https://mcp.notion.com/mcp"
+
+      $md5_1 = [System.Security.Cryptography.MD5]::Create()
+      $bytes_1 = [System.Text.Encoding]::UTF8.GetBytes($url)
+      $hashHex_1 = [System.BitConverter]::ToString($md5_1.ComputeHash($bytes_1)) -replace '-', ''
+
+      $md5_2 = [System.Security.Cryptography.MD5]::Create()
+      $bytes_2 = [System.Text.Encoding]::UTF8.GetBytes($url)
+      $hashHex_2 = [System.BitConverter]::ToString($md5_2.ComputeHash($bytes_2)) -replace '-', ''
+
+      $hashHex_1.ToLower() | Should -Be $hashHex_2.ToLower()
+    }
+  }
+
+  Context "File Operations with Mocked Directory" {
+
+    It "should create mock OAuth file with correct hash prefix" {
+      # Calculate the expected hash
+      $url = "https://mcp.notion.com/mcp"
+      $md5 = [System.Security.Cryptography.MD5]::Create()
+      $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+      $hashBytes = $md5.ComputeHash($bytes)
+      $hashHex = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
+      $fullHash = $hashHex.ToLower()
+
+      # Create mock file in the mock directory (NOT real OAuth directory)
+      $mockFilePath = Join-Path $script:MockOauthDir "$fullHash-test.json"
+      '{"token": "mock_token"}' | Set-Content -LiteralPath $mockFilePath
+
+      # Verify the file exists in mock directory
+      Test-Path $mockFilePath | Should -BeTrue
+
+      # Safety verification: ensure file was created in mock directory, not real directory
+      $mockFilePath | Should -Match "^$([regex]::Escape($script:MockOauthDir))"
+      $mockFilePath | Should -Not -Match "^$([regex]::Escape($script:RealOauthDir))"
+    }
+
+    It "should find files in mock directory matching the hash pattern" {
+      # Calculate the expected hash
+      $url = "https://mcp.notion.com/mcp"
+      $md5 = [System.Security.Cryptography.MD5]::Create()
+      $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+      $hashBytes = $md5.ComputeHash($bytes)
+      $hashHex = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
+      $fullHash = $hashHex.ToLower()
+
+      # Create mock file
+      $mockFilePath = Join-Path $script:MockOauthDir "$fullHash-test.json"
+      '{"token": "mock_token"}' | Set-Content -LiteralPath $mockFilePath
+
+      # Search in mock directory only
+      $targetFiles = Get-ChildItem -Path $script:MockOauthDir -Filter "$fullHash*.json" -ErrorAction SilentlyContinue
+      $targetFiles | Should -Not -BeNullOrEmpty
+      $targetFiles.Count | Should -Be 1
+    }
+
+    It "should not find files when no matching hash exists in mock directory" {
+      # Create a file with a different hash prefix in mock directory
+      $wrongHash = "00000000000000000000000000000000"
+      $mockFilePath = Join-Path $script:MockOauthDir "$wrongHash-test.json"
+      '{"token": "mock_token"}' | Set-Content -LiteralPath $mockFilePath
+
+      # Calculate the correct hash (should not match)
+      $url = "https://mcp.notion.com/mcp"
+      $md5 = [System.Security.Cryptography.MD5]::Create()
+      $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+      $hashBytes = $md5.ComputeHash($bytes)
+      $hashHex = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
+      $fullHash = $hashHex.ToLower()
+
+      # Search in mock directory (should not find the wrong hash file)
+      $targetFiles = Get-ChildItem -Path $script:MockOauthDir -Filter "$fullHash*.json" -ErrorAction SilentlyContinue
+      $targetFiles | Should -BeNullOrEmpty
+    }
+  }
+
+  Context "Script Execution with Mocked Environment" {
+
+    It "should execute without errors when OAuth directory does not exist" {
+      # Create a non-existent path for testing
+      $nonExistentDir = Join-Path $env:TEMP "NonExistent-$(Get-Random)"
+
+      # Script should not throw even if directory doesn't exist
+      { & $script:ScriptPath -OauthDir $nonExistentDir } | Should -Not -Throw
+    }
+
+    It "should execute with mock directory parameter and not throw" {
+      # Run script with mock directory parameter - should not throw
+      { & $script:ScriptPath -OauthDir $script:MockOauthDir } | Should -Not -Throw
+    }
+
+    It "should report 'not found' when mock directory is empty" {
+      # Ensure mock directory is empty
+      (Get-ChildItem $script:MockOauthDir).Count | Should -Be 0
+
+      # Run script with PassThru to capture result
+      $result = & $script:ScriptPath -OauthDir $script:MockOauthDir -PassThru -Verbose
+
+      # Verify result contains expected message
+      $result.Message | Should -Be "No corresponding Notion MCP JSON file found."
+    }
+  }
+
+  Context "File Deletion with Mocked Directory" {
+
+    It "should delete matching OAuth file in mock directory" {
+      # Calculate the expected hash
+      $url = "https://mcp.notion.com/mcp"
+      $md5 = [System.Security.Cryptography.MD5]::Create()
+      $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+      $hashBytes = $md5.ComputeHash($bytes)
+      $hashHex = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
+      $fullHash = $hashHex.ToLower()
+
+      # Create mock file
+      $mockFilePath = Join-Path $script:MockOauthDir "$fullHash.json"
+      '{"token": "mock_token"}' | Set-Content -LiteralPath $mockFilePath
+
+      # Verify file exists before
+      Test-Path $mockFilePath | Should -BeTrue
+
+      # Run script with mock directory and PassThru
+      $result = & $script:ScriptPath -OauthDir $script:MockOauthDir -PassThru -Verbose
+
+      # Verify file was deleted
+      Test-Path $mockFilePath | Should -BeFalse
+
+      # Verify success result
+      $result.Success | Should -BeTrue
+      $result.FilesDeleted.Count | Should -Be 1
+    }
+
+    It "should report 'not found' when mock directory is empty" {
+      # Ensure mock directory is empty
+      (Get-ChildItem $script:MockOauthDir).Count | Should -Be 0
+
+      # Run script with PassThru to capture result
+      $result = & $script:ScriptPath -OauthDir $script:MockOauthDir -PassThru -Verbose
+
+      # Verify not found message
+      $result.Message | Should -Be "No corresponding Notion MCP JSON file found."
+    }
+  }
+
+  Context "Error Handling" {
+
+    It "should handle empty mock OAuth directory gracefully" {
+      # Ensure the mock directory exists but is empty
+      Test-Path $script:MockOauthDir | Should -BeTrue
+      (Get-ChildItem $script:MockOauthDir).Count | Should -Be 0
+
+      # Script should not throw on empty directory
+      { & $script:ScriptPath -OauthDir $script:MockOauthDir } | Should -Not -Throw
+    }
+  }
+
+  Context "Safety Checks" {
+
+    It "should use isolated test directory, not production OAuth directory" {
+      # Verify mock directory is in TEMP, not in USERPROFILE
+      $script:MockOauthDir | Should -Match "^$([regex]::Escape($env:TEMP))"
+      $script:MockOauthDir | Should -Not -Match "^$([regex]::Escape($env:USERPROFILE))"
+    }
+
+    It "should have unique test directory name to avoid conflicts" {
+      # Each test run should use a unique directory
+      $script:MockOauthDir | Should -Match "CherryStudioTest-OAuth-"
+    }
+  }
+}


### PR DESCRIPTION
### Description
Adds a utility script to reset the OAuth cache for Cherry Studio's Notion MCP integration. This provides a simple way to force re-authorization when the existing token is invalid or corrupted, without needing to manually locate and delete the correct cache file.

### Key Changes
- **`feat`**: Introduces the `Reset-CherryStudioNotionMCP.ps1` script, which identifies and removes the Notion MCP OAuth file based on a hash of its URL.
- **`test`**: Implements a comprehensive Pester test suite that runs against a mocked directory, ensuring no production OAuth files are accidentally deleted during testing.
- **`docs`**: Updates the root `README.md` and adds a dedicated `README.md` for the new `CherryStudio` module to document the script's usage and requirements.

### Technical Notes
The script replicates Cherry Studio's internal logic by using an MD5 hash of the `https://mcp.notion.com/mcp` URL to locate the correct cache file within `~/.cherrystudio/config/mcp/oauth`.