### PR TITLE
🔒️ fix(thebrain): add CSV injection sanitization and test for malicious links

### DIFF
--- a/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
+++ b/Tests/theBrain/Get-TheBrainNotesLinks.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Get-TheBrainNotesLinks.ps1" {
     $tempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "Test-GetTheBrainLinks") -Force
     $thought1Dir = New-Item -Path (Join-Path $tempDir "Thought1") -ItemType Directory
     $thought2Dir = New-Item -Path (Join-Path $tempDir "Thought2") -ItemType Directory
-    $backupDir = New-Item -Path (Join-Path $tempDir "Backup") -ItemType Directory
+    $backupDir = New-Item -ItemType Directory -Path (Join-Path $tempDir "Backup") -Force
     $thought3Dir = New-Item -Path (Join-Path $backupDir "Thought3") -ItemType Directory
 
     # # Create dummy Notes.md files
@@ -87,6 +87,63 @@ Describe "Get-TheBrainNotesLinks.ps1" {
       $csvContent = Import-Csv -Path $outputCsv
       $csvContent.URL | Should -Be "https://www.google.com"
 
+      Remove-Item -Path $outputCsv -Force
+    }
+
+    It "should sanitize fields to prevent CSV injection" {
+      $maliciousLinkText = '=HYPERLINK("cmd.exe","/c dir")'
+      $maliciousURL = '+A1+B1'
+      $maliciousContent = "This note contains a [$maliciousLinkText]($maliciousURL)."
+      $maliciousNotesDir = New-Item -ItemType Directory -Path (Join-Path $tempDir "ThoughtMalicious") -Force
+      $maliciousNotesFile = Join-Path $maliciousNotesDir "Notes.md"
+      Set-Content -Path $maliciousNotesFile -Value $maliciousContent
+
+      # Mock Get-ChildItem
+      Mock Get-ChildItem {
+            param($Path, $Filter, $Recurse, $Directory, $Exclude)
+            if ($Filter -eq 'Notes.md') {
+                # This is the call that searches for Notes.md files
+                return @(Get-Item $maliciousNotesFile)
+            }
+            if ($Directory) {
+                # This is the call that gets the base directory for thebrain notes
+                return New-Item -ItemType Directory -Path (Join-Path $tempDir "ThoughtMalicious") -Force
+            }
+            return $null # Default for other Get-ChildItem calls
+        }
+
+      # Mock Select-String to return the malicious link
+      Mock Select-String {
+            [PSCustomObject]@{
+                Path       = $maliciousNotesFile
+                LineNumber = 1
+                Matches    = @(
+                    [PSCustomObject]@{ # This is a single 'Match' object
+                        Groups = @(
+                            [PSCustomObject]@{ Value = "$maliciousLinkText($maliciousURL)" }, # Group 0 (full match, approximate)
+                            [PSCustomObject]@{ Value = $maliciousLinkText }, # Group 1
+                            [PSCustomObject]@{ Value = $maliciousURL }      # Group 2
+                        )
+                    }
+                )
+            }
+        } -ParameterFilter { $_.FullName -eq $maliciousNotesFile }
+
+
+      $outputCsv = Join-Path $tempDir "malicious_links.csv"
+      & $script:ScriptPath -Path $tempDir -OutputPath $outputCsv
+
+      Test-Path $outputCsv | Should -Be $true
+      $importedCsv = Import-Csv -Path $outputCsv
+
+      # The first (and only) data row should be the malicious one
+      $maliciousRow = $importedCsv[0]
+
+      $maliciousRow.LinkText | Should -Be "'$maliciousLinkText"
+      $maliciousRow.URL | Should -Be "'$maliciousURL"
+
+      Remove-Item -Path $maliciousNotesFile -Force
+      Remove-Item -Path $maliciousNotesDir -Force
       Remove-Item -Path $outputCsv -Force
     }
   }

--- a/theBrain/Get-TheBrainNotesLinks.ps1
+++ b/theBrain/Get-TheBrainNotesLinks.ps1
@@ -67,7 +67,17 @@ try {
 
     # Save the results as a CSV file if an output path is specified
     if ($OutputPath) {
-        $LinkList | Export-Csv -Path $OutputPath -Encoding UTF8 -NoTypeInformation
+        # Sanitize data for CSV export to prevent CSV injection.
+        # Prepend a single quote to values starting with potentially executable characters.
+        $CsvData = $LinkList | ForEach-Object {
+            [PSCustomObject]@{
+                Path       = $_.Path
+                LineNumber = $_.LineNumber
+                LinkText   = if ($_.LinkText -match '^[=@+-]') { "'$($_.LinkText)" } else { $_.LinkText }
+                URL        = if ($_.URL -match '^[=@+-]') { "'$($_.URL)" } else { $_.URL }
+            }
+        }
+        $CsvData | Export-Csv -Path $OutputPath -Encoding UTF8 -NoTypeInformation
         Write-Host "Results saved to $OutputPath"
     }
 } catch {


### PR DESCRIPTION
Prevents CSV injection by prepending single quotes to values starting with =, @, +, or -, and adds a test case using malicious link content to verify the sanitization works correctly.